### PR TITLE
feat(redis): add simple cache

### DIFF
--- a/pkg/cache.go
+++ b/pkg/cache.go
@@ -55,8 +55,8 @@ type Response struct {
 	Frequency int
 }
 
-// Client data structure for HTTP cache middleware.
-type Client struct {
+// Cache data structure for HTTP cache middleware.
+type Cache struct {
 	adapter            Adapter
 	ttl                time.Duration
 	refreshKey         string
@@ -65,22 +65,22 @@ type Client struct {
 }
 
 // HTTPHandlerMiddleware is the HTTP cache middleware handler.
-func (c *Client) HTTPHandlerMiddleware(next http.Handler) http.Handler {
-	return &cacheHTTPHandler{
+func (c *Cache) HTTPHandlerMiddleware(next http.Handler) http.Handler {
+	return &cachedHTTPHandler{
 		next:   next,
 		client: c,
 	}
 }
 
 // RoundTripperMiddleware is the HTTP cache middleware for RoundTripper.
-func (c *Client) RoundTripperMiddleware(next http.RoundTripper) http.RoundTripper {
+func (c *Cache) RoundTripperMiddleware(next http.RoundTripper) http.RoundTripper {
 	return &cacheRoundTripper{
 		next:   next,
 		client: c,
 	}
 }
 
-func (c *Client) cacheableMethod(method string) bool {
+func (c *Cache) cacheableMethod(method string) bool {
 	for _, m := range c.methods {
 		if method == m {
 			return true

--- a/pkg/cache_option.go
+++ b/pkg/cache_option.go
@@ -7,13 +7,13 @@ import (
 	"time"
 )
 
-// ClientOption is used to set Client settings.
-type ClientOption func(c *Client) error
+// CacheOption is used to set Client settings.
+type CacheOption func(c *Cache) error
 
-// NewClient initializes the cache HTTP middleware client with the given
+// NewCache initializes the cache HTTP middleware client with the given
 // options.
-func NewClient(opts ...ClientOption) (*Client, error) {
-	c := &Client{}
+func NewCache(opts ...CacheOption) (*Cache, error) {
+	c := &Cache{}
 
 	for _, opt := range opts {
 		if err := opt(c); err != nil {
@@ -34,18 +34,18 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 	return c, nil
 }
 
-// ClientWithAdapter sets the adapter type for the HTTP cache
+// CacheWithAdapter sets the adapter type for the HTTP cache
 // middleware client.
-func ClientWithAdapter(a Adapter) ClientOption {
-	return func(c *Client) error {
+func CacheWithAdapter(a Adapter) CacheOption {
+	return func(c *Cache) error {
 		c.adapter = a
 		return nil
 	}
 }
 
-// ClientWithTTL sets how long each response is going to be cached.
-func ClientWithTTL(ttl time.Duration) ClientOption {
-	return func(c *Client) error {
+// CacheWithTTL sets how long each response is going to be cached.
+func CacheWithTTL(ttl time.Duration) CacheOption {
+	return func(c *Cache) error {
 		if int64(ttl) < 1 {
 			return fmt.Errorf("cache client ttl %v is invalid", ttl)
 		}
@@ -56,19 +56,19 @@ func ClientWithTTL(ttl time.Duration) ClientOption {
 	}
 }
 
-// ClientWithRefreshKey sets the parameter key used to free a request
+// CacheWithRefreshKey sets the parameter key used to free a request
 // cached response. Optional setting.
-func ClientWithRefreshKey(refreshKey string) ClientOption {
-	return func(c *Client) error {
+func CacheWithRefreshKey(refreshKey string) CacheOption {
+	return func(c *Cache) error {
 		c.refreshKey = refreshKey
 		return nil
 	}
 }
 
-// ClientWithMethods sets the acceptable HTTP methods to be cached.
+// CacheWithMethods sets the acceptable HTTP methods to be cached.
 // Optional setting. If not set, default is "GET".
-func ClientWithMethods(methods []string) ClientOption {
-	return func(c *Client) error {
+func CacheWithMethods(methods []string) CacheOption {
+	return func(c *Cache) error {
 		for _, method := range methods {
 			if method != http.MethodGet && method != http.MethodPost {
 				return fmt.Errorf("invalid method %s", method)
@@ -79,10 +79,10 @@ func ClientWithMethods(methods []string) ClientOption {
 	}
 }
 
-// ClientWithExpiresHeader enables middleware to add an Expires header to responses.
+// CacheWithExpiresHeader enables middleware to add an Expires header to responses.
 // Optional setting. If not set, default is false.
-func ClientWithExpiresHeader() ClientOption {
-	return func(c *Client) error {
+func CacheWithExpiresHeader() CacheOption {
+	return func(c *Cache) error {
 		c.writeExpiresHeader = true
 		return nil
 	}

--- a/pkg/cache_proxy.go
+++ b/pkg/cache_proxy.go
@@ -1,4 +1,4 @@
-// Package pkg provides a reverse proxy with Redis caching capabilities.
+// Package pkg provides a reverse proxy with cache functionality.
 package pkg
 
 import (
@@ -11,23 +11,24 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
+// NewCacheProxy creates a new cache proxy with the given host and redis server.
 func NewCacheProxy(host string, redisServer map[string]string) http.Handler {
 	domain, err := url.Parse(host)
 	if err != nil {
 		log.Fatalf("Failed to parse URL: %v", err)
 	}
 	rp := httputil.NewSingleHostReverseProxy(domain)
-	client, err := NewClient(
-		ClientWithAdapter(NewRedisAdapter(&redis.RingOptions{
+	cache, err := NewCache(
+		CacheWithAdapter(NewRedisAdapter(&redis.RingOptions{
 			Addrs: redisServer,
 		})),
-		// cache both GET and POST methods
-		ClientWithMethods([]string{http.MethodGet, http.MethodPost}),
+		// cache both GET and PUT methods
+		CacheWithMethods([]string{http.MethodGet, http.MethodPost}),
 		// cache responses for 24 hours
-		ClientWithTTL(24*time.Hour),
+		CacheWithTTL(24*time.Hour),
 	)
 	if err != nil {
 		log.Fatalf("Failed to create client: %v", err)
 	}
-	return client.HTTPHandlerMiddleware(rp)
+	return cache.HTTPHandlerMiddleware(rp)
 }

--- a/pkg/cache_proxy.go
+++ b/pkg/cache_proxy.go
@@ -2,10 +2,11 @@
 package pkg
 
 import (
-	"log"
+	"log/slog"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"os"
 	"time"
 
 	"github.com/redis/go-redis/v9"
@@ -15,7 +16,8 @@ import (
 func NewCacheProxy(host string, redisServer map[string]string) http.Handler {
 	domain, err := url.Parse(host)
 	if err != nil {
-		log.Fatalf("Failed to parse URL: %v", err)
+		slog.Error("Failed to parse URL", "host", host, "error", err)
+		os.Exit(1)
 	}
 	rp := httputil.NewSingleHostReverseProxy(domain)
 	cache, err := NewCache(
@@ -28,7 +30,8 @@ func NewCacheProxy(host string, redisServer map[string]string) http.Handler {
 		CacheWithTTL(24*time.Hour),
 	)
 	if err != nil {
-		log.Fatalf("Failed to create client: %v", err)
+		slog.Error("Failed to create client", "error", err)
+		os.Exit(1)
 	}
 	return cache.HTTPHandlerMiddleware(rp)
 }

--- a/pkg/middleware.go
+++ b/pkg/middleware.go
@@ -8,12 +8,13 @@ import (
 	"time"
 )
 
-type cacheHTTPHandler struct {
+// cachedHTTPHandler is a `http.Handler` that caches the responses.
+type cachedHTTPHandler struct {
 	next   http.Handler
-	client *Client
+	client *Cache
 }
 
-func (h *cacheHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (h *cachedHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	c := h.client
 	next := h.next
 	if c.cacheableMethod(r.Method) {
@@ -87,9 +88,10 @@ func (h *cacheHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	next.ServeHTTP(w, r)
 }
 
+// cacheRoundTripper is a `http.RoundTripper` that caches the responses.
 type cacheRoundTripper struct {
 	next   http.RoundTripper
-	client *Client
+	client *Cache
 }
 
 func (rt *cacheRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {

--- a/pkg/middleware.go
+++ b/pkg/middleware.go
@@ -3,6 +3,7 @@ package pkg
 import (
 	"bytes"
 	"io"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -24,6 +25,7 @@ func (h *cachedHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			body, err := io.ReadAll(r.Body)
 			defer r.Body.Close()
 			if err != nil {
+				slog.Warn("Failed to read request body", "method", r.Method, "url", r.URL.String(), "error", err)
 				next.ServeHTTP(w, r)
 				return
 			}
@@ -39,16 +41,23 @@ func (h *cachedHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			r.URL.RawQuery = params.Encode()
 			key = generateKey(r.URL.String())
 
+			slog.Info("Cache refresh requested", "key", key, "method", r.Method, "url", r.URL.String())
 			c.adapter.Release(r.Context(), key)
 		} else {
 			b, ok := c.adapter.Get(r.Context(), key)
-			response := BytesToResponse(b)
 			if ok {
+				response, err := BytesToResponse(b)
+				if err != nil {
+					slog.Warn("Failed to deserialize cached response", "key", key, "error", err)
+					next.ServeHTTP(w, r)
+					return
+				}
 				if response.Expiration.After(time.Now()) {
 					response.LastAccess = time.Now()
 					response.Frequency++
 					c.adapter.Set(key, response.Bytes(), response.Expiration)
 
+					slog.Info("Cache hit", "key", key, "method", r.Method, "url", r.URL.String(), "frequency", response.Frequency)
 					//w.WriteHeader(http.StatusNotModified)
 					for k, v := range response.Header {
 						w.Header().Set(k, strings.Join(v, ","))
@@ -60,6 +69,7 @@ func (h *cachedHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
+				slog.Info("Cache entry expired", "key", key, "expiration", response.Expiration)
 				c.adapter.Release(r.Context(), key)
 			}
 		}
@@ -80,6 +90,9 @@ func (h *cachedHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				Frequency:  1,
 			}
 			c.adapter.Set(key, response.Bytes(), response.Expiration)
+			slog.Info("Cache miss - new entry created", "key", key, "method", r.Method, "url", r.URL.String(), "status_code", statusCode, "expires", expires)
+		} else {
+			slog.Warn("Response not cached due to error status", "key", key, "method", r.Method, "url", r.URL.String(), "status_code", statusCode)
 		}
 
 		return
@@ -118,8 +131,11 @@ func (rt *cacheRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) 
 			rt.client.adapter.Release(r.Context(), key)
 		} else {
 			b, ok := rt.client.adapter.Get(r.Context(), key)
-			response := BytesToResponse(b)
 			if ok {
+				response, err := BytesToResponse(b)
+				if err != nil {
+					return rt.next.RoundTrip(r)
+				}
 				if response.Expiration.After(time.Now()) {
 					response.LastAccess = time.Now()
 					response.Frequency++

--- a/pkg/pg_middleware.go
+++ b/pkg/pg_middleware.go
@@ -1,1 +1,0 @@
-package pkg

--- a/pkg/redis_adapter.go
+++ b/pkg/redis_adapter.go
@@ -85,10 +85,10 @@ func NewRedisAdapter(opt *redis.RingOptions) *RedisAdapter {
 	ring := redis.NewRing(opt)
 	store := cache.New(&cache.Options{
 		Redis: ring,
-		Marshal: func(v interface{}) ([]byte, error) {
+		Marshal: func(v any) ([]byte, error) {
 			return msgpack.Marshal(v)
 		},
-		Unmarshal: func(b []byte, v interface{}) error {
+		Unmarshal: func(b []byte, v any) error {
 			return msgpack.Unmarshal(b, v)
 		},
 		LocalCache: cache.NewTinyLFU(1000, 10*time.Minute),

--- a/pkg/redis_adapter.go
+++ b/pkg/redis_adapter.go
@@ -26,6 +26,7 @@ package pkg
 
 import (
 	"context"
+	"log/slog"
 	"time"
 
 	"github.com/go-redis/cache/v9"
@@ -69,14 +70,14 @@ func (ra *RedisAdapter) Set(key uint64, response []byte, expiration time.Time) {
 		TTL:   time.Until(expiration),
 	})
 	if err != nil {
-		log.Printf("Failed to set cache for key %s: %v", KeyAsString(key), err)
+		slog.Error("Failed to set cache", "key", KeyAsString(key), "error", err)
 	}
 }
 
 // Release implements the cache Adapter interface Release method.
 func (ra *RedisAdapter) Release(ctx context.Context, key uint64) {
 	if err := ra.store.Delete(ctx, KeyAsString(key)); err != nil {
-		log.Printf("failed to delete cache entry for key %d: %v", key, err)
+		slog.Error("Failed to delete cache entry", "key", key, "error", err)
 	}
 }
 

--- a/pkg/slog.go
+++ b/pkg/slog.go
@@ -1,0 +1,56 @@
+package pkg
+
+import (
+	"log/slog"
+	"os"
+	"strings"
+)
+
+var logger *slog.Logger
+
+// init initializes the logger with proper configuration
+func init() {
+	// Get log level from environment variable, default to INFO
+	logLevel := slog.LevelInfo
+	if levelStr := os.Getenv("LOG_LEVEL"); levelStr != "" {
+		switch strings.ToUpper(levelStr) {
+		case "DEBUG":
+			logLevel = slog.LevelDebug
+		case "INFO":
+			logLevel = slog.LevelInfo
+		case "WARN":
+			logLevel = slog.LevelWarn
+		case "ERROR":
+			logLevel = slog.LevelError
+		}
+	}
+
+	// Set up structured logging with JSON format and proper level
+	opts := &slog.HandlerOptions{
+		Level:     logLevel,
+		AddSource: true,
+	}
+
+	// Use JSON handler for structured logging
+	handler := slog.NewJSONHandler(os.Stdout, opts)
+	logger = slog.New(handler)
+
+	// Replace the default slog logger
+	slog.SetDefault(logger)
+}
+
+// GetLogger returns the configured logger instance
+func GetLogger() *slog.Logger {
+	return logger
+}
+
+// SetLogLevel allows runtime configuration of log level
+func SetLogLevel(level slog.Level) {
+	opts := &slog.HandlerOptions{
+		Level:     level,
+		AddSource: true,
+	}
+	handler := slog.NewJSONHandler(os.Stdout, opts)
+	logger = slog.New(handler)
+	slog.SetDefault(logger)
+}


### PR DESCRIPTION
- migrates [http-cache](https://github.com/victorspringer/http-cache) to more recent version of redis.
- rename `Client` to `Cache`.
- use `slog` instead.